### PR TITLE
Format container partition as ext4

### DIFF
--- a/create_container.sh
+++ b/create_container.sh
@@ -119,8 +119,10 @@ ROOTFS=${STORAGE}:${DISK_REF-}${DISK}
 # Create LXC
 msg "Creating LXC container..."
 pvesm alloc $STORAGE $CTID $DISK 4G --format ${DISK_FORMAT:-raw} >/dev/null
-if [ "$STORAGE_TYPE" != "zfspool" ]; then
-  mke2fs $(pvesm path $ROOTFS) &>/dev/null
+if [ "$STORAGE_TYPE" == "zfspool" ]; then
+  warn "Some addons may not work due to ZFS not supporting 'fallocate'."
+else
+  mkfs.ext4 $(pvesm path $ROOTFS) &>/dev/null
 fi
 ARCH=$(dpkg --print-architecture)
 HOSTNAME=hassio


### PR DESCRIPTION
Some addons use `fallocate` which will fail under ext2 partition. ZFS storage pools do not support `fallocate`. #5